### PR TITLE
fix TypeError in HtmlFormatter.format

### DIFF
--- a/telegram_handler/formatters.py
+++ b/telegram_handler/formatters.py
@@ -44,6 +44,8 @@ class HtmlFormatter(TelegramFormatter):
         """
         :param logging.LogRecord record:
         """
+        super(HtmlFormatter, self).format(record)
+
         if record.funcName:
             record.funcName = escape_html(str(record.funcName))
         if record.name:
@@ -60,7 +62,8 @@ class HtmlFormatter(TelegramFormatter):
                 record.levelname += ' ' + EMOJI.BLUE_CIRCLE
             else:
                 record.levelname += ' ' + EMOJI.RED_CIRCLE
-        return super(HtmlFormatter, self).format(record)
+
+        return self.fmt % record.__dict__
 
     def formatException(self, *args, **kwargs):
         string = super(HtmlFormatter, self).formatException(*args, **kwargs)


### PR DESCRIPTION
  File "/lib/python3.4/site-packages/telegram_handler/formatters.py", line 63, in format
    return super(HtmlFormatter, self).format(record)
  File "/lib/python3.4/logging/__init__.py", line 565, in format
    record.message = record.getMessage()
  File "/lib/python3.4/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting