### PR TITLE
Removed print()-calls in HtmlFormatter

### DIFF
--- a/telegram_handler/formatters.py
+++ b/telegram_handler/formatters.py
@@ -53,12 +53,9 @@ class HtmlFormatter(TelegramFormatter):
         if record.msg:
             record.msg = escape_html(record.getMessage())
         if self.use_emoji:
-            print(record.name, record.levelno, record.levelname)
             if record.levelno == logging.DEBUG:
-                print(record.levelno, record.levelname)
                 record.levelname += ' ' + EMOJI.WHITE_CIRCLE
             elif record.levelno == logging.INFO:
-                print(record.levelno, record.levelname)
                 record.levelname += ' ' + EMOJI.BLUE_CIRCLE
             else:
                 record.levelname += ' ' + EMOJI.RED_CIRCLE


### PR DESCRIPTION
Removed some calls to print() in HtmlFormatter which I guess are left-over debugging statements.